### PR TITLE
Force unbuffered stdout

### DIFF
--- a/src/stdio_socket/expose.py
+++ b/src/stdio_socket/expose.py
@@ -50,6 +50,10 @@ async def _expose_stdio_async(
     command: str, socket_path: Path, ptty: bool, stdin: bool, ctrl_d: bool
 ):
     os.system("stty -echo raw")
+
+    # force line buffering
+    command = f"stdbuf -oL -eL {command}"
+
     if ptty:
         # these stty settings and psuedo-tty make bash and vim work
         command = f'pptty "{command}"'


### PR DESCRIPTION
This is in search of a fix for #13.

I believe what happens is that the python executable doesn't respect `PYTHONUNBUFFERED=1` when launched through an entry point script. This solution should bootstrap an unbuffered executable.