### PR TITLE
fix: `stdio-expose --stdin` hangs when subprocess produces large output

### DIFF
--- a/src/stdio_socket/expose.py
+++ b/src/stdio_socket/expose.py
@@ -210,7 +210,14 @@ async def _expose_stdio_async(
 
         reader = asyncio.StreamReader()
         protocol = asyncio.StreamReaderProtocol(reader)
-        await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
+        await asyncio.get_running_loop().connect_read_pipe(lambda: protocol, sys.stdin)
+        # connect_read_pipe sets O_NONBLOCK on the stdin fd. On a TTY, stdin (fd 0)
+        # and stdout (fd 1) share the same open file description, so stdout also
+        # becomes non-blocking. This causes do_stdout's synchronous
+        # sys.stdout.buffer.write() calls to raise BlockingIOError, crashing the
+        # task and leaving the subprocess pipe unread — deadlocking process.wait().
+        # Restore stdout to blocking mode to fix this.
+        os.set_blocking(sys.stdout.fileno(), True)
 
         await do_stdin(reader)
 

--- a/src/stdio_socket/expose.py
+++ b/src/stdio_socket/expose.py
@@ -217,7 +217,11 @@ async def _expose_stdio_async(
         # sys.stdout.buffer.write() calls to raise BlockingIOError, crashing the
         # task and leaving the subprocess pipe unread — deadlocking process.wait().
         # Restore stdout to blocking mode to fix this.
-        os.set_blocking(sys.stdout.fileno(), True)
+        try:
+            if sys.stdin.isatty() and sys.stdout.isatty():
+                os.set_blocking(sys.stdout.fileno(), True)
+        except (OSError, AttributeError, ValueError):
+            pass
 
         await do_stdin(reader)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
+import os
+import pty
 import subprocess
 import sys
+import time
 
 from stdio_socket import __version__
 
@@ -7,3 +10,53 @@ from stdio_socket import __version__
 def test_cli_version():
     cmd = [sys.executable, "-m", "stdio_socket", "--version"]
     assert subprocess.check_output(cmd).decode().strip() == __version__
+
+
+def test_stdin_flag_does_not_hang_with_large_output():
+    """Regression test for the O_NONBLOCK propagation hang on a TTY.
+
+    connect_read_pipe() sets O_NONBLOCK on stdin (fd 0). On a TTY, stdin and
+    stdout share the same open file description, so stdout also becomes
+    non-blocking. This caused BlockingIOError in do_stdout, leaving the
+    subprocess pipe unread and deadlocking process.wait() indefinitely.
+
+    A real PTY is required to reproduce the bug: with plain pipes fd 0 and fd 1
+    are independent file descriptions so O_NONBLOCK on one does not affect the
+    other.
+    """
+    large_output_cmd = f"{sys.executable} -c \"print('x' * 200_000)\""
+
+    master_fd, slave_fd = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            ["stdio-expose", "--stdin", large_output_cmd],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        slave_fd = -1
+
+        # Drain the master end so the PTY buffer never fills and blocks the writer.
+        # OSError(EIO) is raised when the slave end closes (process exited) — that's
+        # the normal termination signal on Linux PTYs.
+        os.set_blocking(master_fd, False)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            try:
+                os.read(master_fd, 4096)
+            except BlockingIOError:
+                if proc.poll() is not None:
+                    break
+                time.sleep(0.05)
+            except OSError:
+                # EIO: slave end closed, process has exited
+                break
+    finally:
+        os.close(master_fd)
+        if slave_fd != -1:
+            os.close(slave_fd)
+
+    proc.wait(timeout=5)
+    assert proc.returncode == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import pty
 import subprocess
@@ -29,7 +30,7 @@ def test_stdin_flag_does_not_hang_with_large_output():
     master_fd, slave_fd = pty.openpty()
     try:
         proc = subprocess.Popen(
-            ["stdio-expose", "--stdin", large_output_cmd],
+            [sys.executable, "-m", "stdio_socket", "--stdin", large_output_cmd],
             stdin=slave_fd,
             stdout=slave_fd,
             stderr=slave_fd,
@@ -50,13 +51,20 @@ def test_stdin_flag_does_not_hang_with_large_output():
                 if proc.poll() is not None:
                     break
                 time.sleep(0.05)
-            except OSError:
-                # EIO: slave end closed, process has exited
-                break
+            except OSError as e:
+                if e.errno == errno.EIO:
+                    # slave end closed, process has exited
+                    break
+                raise
     finally:
         os.close(master_fd)
         if slave_fd != -1:
             os.close(slave_fd)
 
-    proc.wait(timeout=5)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+        raise
     assert proc.returncode == 0


### PR DESCRIPTION
Closes #26 

## Problem

`stdio-expose --stdin <cmd>` would hang indefinitely if the wrapped command wrote more than ~4 KB of output to stdout/stderr.

### Root cause

`monitor_system_stdin()` used `asyncio.connect_read_pipe()` to attach to `sys.stdin`. That call internally invokes `os.set_blocking(fd0, False)`. On a TTY, **stdin (fd 0) and stdout (fd 1) share the same open file description** — so stdout also becomes non-blocking as a side effect.

This caused `do_stdout`'s `sys.stdout.buffer.write()` to raise `BlockingIOError` once the PTY write buffer was full, crashing the asyncio task. With nothing draining the subprocess's stdout pipe, the pipe buffer (64 KB) filled up, and the subprocess blocked forever trying to write. Since `process.wait()` has no timeout, `stdio-expose` hung indefinitely.

The bug only manifests with `--stdin` on a real TTY — with piped I/O, fd 0 and fd 1 are independent file descriptions and O_NONBLOCK on one doesn't affect the other.

## Fix

After `connect_read_pipe()` runs, immediately call `os.set_blocking(sys.stdout.fileno(), True)` to restore blocking mode on stdout. Also replaces the deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()`.

## Test

Adds a regression test that wraps `stdio-expose --stdin` in a real PTY (necessary to reproduce the shared file-description condition) and asserts it exits cleanly when the subprocess emits 200 KB of output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where using the `--stdin` flag with large output could cause the application to hang on terminal environments. Proper terminal mode handling is now restored during asynchronous operations.

* **Tests**
  * Added regression test to prevent future hangs when using `--stdin` flag with large amounts of output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->